### PR TITLE
chore: bump to 0.14.2

### DIFF
--- a/daytona.rb
+++ b/daytona.rb
@@ -1,20 +1,20 @@
 class Daytona < Formula
     desc "Daytona CLI"
     homepage "https://daytona.io"
-    version "0.14.1"
+    version "0.14.2"
   
     if OS.mac? && Hardware::CPU.arm?
       url "https://download.daytona.io/cli/#{version}/daytona-darwin-arm64"
-      sha256 "d3e6ea786013104cc3ee63e68d45a776b1af3cac3d66b47c650dfd0d9bf42238"
+      sha256 "5d78d5044f37f6852e47cf6214125789d3c9cbb233aed682ffe1d13b1cb01a0c"
     elsif OS.mac? && Hardware::CPU.intel?    
       url "https://download.daytona.io/cli/#{version}/daytona-darwin-amd64"    
-      sha256 "9ad6954264b65bd7a5df10c3322660e09ff864ebec92a7c18a498424b5699773"
+      sha256 "2f586b040bfb0dce88b7c2276d02f73763a9093a8b825f330129192b2f466e99"
     elsif OS.linux? && Hardware::CPU.intel?
       url "https://download.daytona.io/cli/#{version}/daytona-linux-amd64"
-      sha256 "161b83829e5a6cd088e77c7b64d403aa5b981a0dcc8f5d6fd49ce0f23b2378c6"
+      sha256 "95c83ba1664208719b5c6c069ee4b3c5d38e21f793dfc76b2d924fad72d72874"
     elsif OS.linux? && Hardware::CPU.arm?
       url "https://download.daytona.io/cli/#{version}/daytona-linux-arm64"
-      sha256 "4e8e49d57403cd20b345df21845a4eab3354458b2cc2ee3c144bbcccee9ddc91"
+      sha256 "450b603ad2860b674d276dcedc1c1979a87d36825e74cbb01b5ace6aa1bd1dff"
     else
       odie "Unsupported OS/ARCH combination"
     end


### PR DESCRIPTION
DO NOT MERGE before organizations are deployed on https://app.daytona.io/