### PR TITLE
docs: add one-time `brew trust` step to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 # Daytona CLI Homebrew Formula
+
 ```sh
+# Install
 brew install daytonaio/cli/daytona
+
+# Trust the tap once so routine `brew upgrade` keeps Daytona up to date
+brew trust daytonaio/cli
+
+# Upgrade
+brew upgrade daytonaio/cli/daytona
 ```
+
+Recent Homebrew versions require third-party taps to be explicitly trusted. Without the one-time `brew trust daytonaio/cli`, a routine `brew upgrade` silently skips this tap and the Daytona CLI goes stale.


### PR DESCRIPTION
Adds the one-time `brew trust daytonaio/cli` step to the tap README, alongside install and upgrade.

Recent Homebrew versions require third-party (non-official) taps to be explicitly trusted. The fully-qualified `brew install daytonaio/cli/daytona` still works, but a routine bare `brew upgrade` now silently skips this tap:

> Warning: Skipping daytonaio/cli because it is not trusted. Run 'brew trust daytonaio/cli' to trust it.

Running `brew trust daytonaio/cli` once keeps routine `brew upgrade` updating the Daytona CLI.

Companion docs change in the main repo: daytonaio/daytona#4953.
